### PR TITLE
Samson to listen on port 3000 for tests

### DIFF
--- a/molecule/shared/create.yml
+++ b/molecule/shared/create.yml
@@ -7,4 +7,4 @@
         image: danihodovic/ansible-samson-test:latest
         name: '{{ molecule_yml.platforms[0].name }}'
         ports:
-          - '9080:9080'
+          - '3000:9080'


### PR DESCRIPTION
This allows us to visually confirm the changes ansible-samson makes are
correct. The default Github oauth application that's configured uses
port 3000 and not 9080.